### PR TITLE
Adicionar exception handler para validação

### DIFF
--- a/src/main/java/com/github/amigoocultoapi/config/AmigoOcultoExceptionHandler.java
+++ b/src/main/java/com/github/amigoocultoapi/config/AmigoOcultoExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.github.amigoocultoapi.config;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.github.amigoocultoapi.responses.ErroResponse;
+
+@RestControllerAdvice
+public class AmigoOcultoExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErroResponse> lidaComErrosDeValidacao(MethodArgumentNotValidException exception) {
+        String mensagem = "";
+
+        for (FieldError error: exception.getFieldErrors()) {
+            mensagem += error.getField() + " " + error.getDefaultMessage() + "\n";
+        }
+
+        return ResponseEntity.badRequest()
+        .body(new ErroResponse(ErroResponse.Tipo.VALIDACAO, mensagem));
+    }
+}

--- a/src/main/java/com/github/amigoocultoapi/controllers/ParticipanteController.java
+++ b/src/main/java/com/github/amigoocultoapi/controllers/ParticipanteController.java
@@ -2,8 +2,9 @@ package com.github.amigoocultoapi.controllers;
 
 import java.util.List;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +17,6 @@ import com.github.amigoocultoapi.services.ParticipanteService;
 
 @RestController
 @RequestMapping("/participantes")
-@Validated
 public class ParticipanteController {
     private ParticipanteService participanteService;
 
@@ -26,7 +26,7 @@ public class ParticipanteController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Participante criarParticipante(@RequestBody Participante participante) {
+    public Participante criarParticipante(@Valid @RequestBody Participante participante) {
         return participanteService.criarParticipante(participante.getNome());
     }
 

--- a/src/main/java/com/github/amigoocultoapi/responses/ErroResponse.java
+++ b/src/main/java/com/github/amigoocultoapi/responses/ErroResponse.java
@@ -1,0 +1,23 @@
+package com.github.amigoocultoapi.responses;
+
+public class ErroResponse {
+    private Tipo tipo;
+    private String mensagem;
+    
+    public ErroResponse(Tipo tipo, String mensagem) {
+        this.tipo = tipo;
+        this.mensagem = mensagem;
+    }
+
+    public Tipo getTipo() {
+        return tipo;
+    }
+
+    public String getMensagem() {
+        return mensagem;
+    }
+
+    public static enum Tipo {
+        VALIDACAO, NEGOCIO;
+    }
+}


### PR DESCRIPTION
Este PR adiciona um exception handler, que caso o usuário faça algum erro de validação, fará a interceptação e mandará uma resposta dizendo quais campos foram incorretamente preenchidos pelo usuário.
O exception handler faz isso olhando o objeto FieldErrors da exception e, para cada erro de validação cometido, coloca nnuma string que será enviada ao usuário seguido de um caractere de nova linha (\n).

Testes feitos:
Post em http://localhost:8080/participantes, enviando {} deu o resultado {"tipo": "VALIDACAO", "mensagem": "nome não deve estar vazio\n"}